### PR TITLE
add basic CSV manifest generation

### DIFF
--- a/hack/generate/manifests.sh
+++ b/hack/generate/manifests.sh
@@ -40,6 +40,7 @@ for arg in $args; do
         --container-tag=${container_tag} \
         --image-pull-policy=${image_pull_policy} \
         --verbosity=${verbosity} \
+        --csv-version=0.0.1 \
         --input-file=${infile} >${outfile}
 done
 

--- a/manifests/release/machineremediationoperator.VERSION.clusterserviceversion.yaml.in
+++ b/manifests/release/machineremediationoperator.VERSION.clusterserviceversion.yaml.in
@@ -1,0 +1,93 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: machine-remediation-operator.{{.CsvVersion}}
+  namespace: placeholder
+  annotations:
+    capabilities: "Full Lifecycle"
+    categories: "Cluster"
+    alm-examples: |
+      [
+        {
+          "apiVersion":"machinehealthchecks.machineremediation.kubevirt.io/v1alpha1",
+          "kind":"MachineHealthCheck",
+          "metadata": {
+            "name":"cluster"
+          },
+          "spec": {
+            "selector": {
+              "matchLabels": {
+                 "machine.openshift.io/cluster-api-cluster": "cluster",
+                 "machine.openshift.io/cluster-api-machine-role": "worker",
+                 "machine.openshift.io/cluster-api-machine-type": "worker",
+                 "machine.openshift.io/cluster-api-machineset": "<machineset>"
+              }
+            },
+            "imagePullPolicy": "IfNotPresent"
+          }
+        }
+      ]
+    description: 'Provides all components to apply different remediation
+      strategies on an unhealthy machine'
+spec:
+  displayName: Machine Remediation
+  description: Deploy additional networking components for Kubernetes
+  keywords:
+    - Cluster
+    - Machine
+    - Remediation
+    - Health-check
+  version: {{.CsvVersion}}
+  maturity: alpha
+  maintainers:
+    - name: <TODO>
+      email: <TODO>
+  provider:
+    name: <TODO>
+  links:
+    - name: Source Code
+      url: https://github.com/kubevirt/machine-remediation-operator
+  icon: []
+  labels:
+    alm-owner-kubevirt: machine-remediation
+    operated-by: machine-remediation
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: machine-remediation
+      operated-by: machine-remediation
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: machine-remediation-operator
+{{.OperatorRules}}
+      deployments:
+        - name: machine-remediation-operator
+          spec:
+{{.OperatorDeploymentSpec}}
+  customresourcedefinitions:
+    owned:
+      - name: machinedisruptionbudgets.machineremediation.kubevirt.io
+        version: v1alpha1
+        kind: MachineDisruptionBudget
+        displayName: Machine Disruption Budget
+        description: Machine Disruption Budget
+      - name: machinehealthchecks.machineremediation.kubevirt.io
+        version: v1alpha1
+        kind: MachineHealthCheck
+        displayName: Machine Health Check
+        description: Machine Health Check
+      - name: machineremediations.machineremediation.kubevirt.io
+        version: v1alpha1
+        kind: MachineRemediation
+        displayName: Machine Remediation
+        description: Machine Remediation

--- a/tools/manifest-templator/BUILD.bazel
+++ b/tools/manifest-templator/BUILD.bazel
@@ -5,7 +5,13 @@ go_library(
     srcs = ["manifest-templator.go"],
     importpath = "kubevirt.io/machine-remediation-operator/tools/manifest-templator",
     visibility = ["//visibility:private"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//pkg/operator/components:go_default_library",
+        "//tools/utils:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/rbac/v1:go_default_library",
+    ],
 )
 
 go_binary(

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -20,23 +20,34 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	"github.com/spf13/pflag"
+
+	"kubevirt.io/machine-remediation-operator/pkg/operator/components"
+	"kubevirt.io/machine-remediation-operator/tools/utils"
 )
 
 type templateData struct {
-	Namespace          string
-	ContainerTag       string
-	ContainerPrefix    string
-	ImagePullPolicy    string
-	Verbosity          string
-	GeneratedManifests map[string]string
+	Namespace              string
+	ContainerTag           string
+	ContainerPrefix        string
+	ImagePullPolicy        string
+	Verbosity              string
+	OperatorDeploymentSpec string
+	OperatorRules          string
+	CsvVersion             string
+	GeneratedManifests     map[string]string
 }
 
 func main() {
@@ -49,7 +60,7 @@ func main() {
 	inputFile := flag.String("input-file", "", "")
 	processFiles := flag.Bool("process-files", false, "")
 	processVars := flag.Bool("process-vars", false, "")
-	
+	csvVersion := flag.String("csv-version", "", "")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -69,12 +80,18 @@ func main() {
 		data.ContainerPrefix = *containerPrefix
 		data.ImagePullPolicy = *imagePullPolicy
 		data.Verbosity = fmt.Sprintf("%s", *verbosity)
+		data.OperatorDeploymentSpec = fixResourceString(getOperatorDeploymentSpec(data), 12)
+		data.OperatorRules = fixResourceString(getOperatorRules(), 10)
+		data.CsvVersion = *csvVersion
 	} else {
 		data.Namespace = "{{.Namespace}}"
 		data.ContainerTag = "{{.ContainerTag}}"
 		data.ContainerPrefix = "{{.ContainerPrefix}}"
 		data.ImagePullPolicy = "{{.ImagePullPolicy}}"
 		data.Verbosity = "{{.Verbosity}}"
+		data.OperatorDeploymentSpec = "{{.OperatorDeploymentSpec}}"
+		data.OperatorRules = "{{.OperatorRules}}"
+		data.CsvVersion = "{{.CsvVersion}}"
 	}
 
 	if *processFiles {
@@ -100,4 +117,52 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func getOperatorDeploymentSpec(data templateData) string {
+	imagePullPolicy := corev1.PullPolicy(data.ImagePullPolicy)
+	deployment := components.NewDeployment(components.ComponentMachineRemediationOperator, data.Namespace, data.ContainerPrefix, data.ContainerTag, imagePullPolicy, data.Verbosity)
+	return objToStr(deployment.Spec)
+}
+
+type clusterRoleRules struct {
+	Rules []rbacv1.PolicyRule `json:"rules"`
+}
+
+func getOperatorRules() string {
+	rule := clusterRoleRules{
+		Rules: components.Rules[components.ComponentMachineRemediationOperator],
+	}
+	return objToStr(rule)
+}
+
+func objToStr(obj interface{}) string {
+	writer := strings.Builder{}
+	err := utils.MarshallObject(obj, &writer)
+	if err != nil {
+		panic(err)
+	}
+	return writer.String()
+}
+
+func fixResourceString(in string, indention int) string {
+	out := strings.Builder{}
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	for scanner.Scan() {
+		line := scanner.Text()
+		// remove separator lines
+		if !strings.HasPrefix(line, "---") {
+			// indent so that it fits into the manifest
+			// spaces is is indention - 2, because we want to have 2 spaces less for being able to start an array
+			spaces := strings.Repeat(" ", indention-2)
+			if strings.HasPrefix(line, "apiGroups") {
+				// spaces + array start
+				out.WriteString(spaces + "- " + line + "\n")
+			} else {
+				// 2 more spaces
+				out.WriteString(spaces + "  " + line + "\n")
+			}
+		}
+	}
+	return out.String()
 }


### PR DESCRIPTION
This commit adds basic CSV manifest generation. There are still some things missing:
- make CSV version configurable from ENV variable
- put CSV version into CSV file name
- fill in missing operator metadata (placeholder `<TODO>`)