### PR TITLE
Move CSV generator to separate binary and add it under operator container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ fmt:
 	./hack/dockerized "./hack/bazel/fmt.sh"
 
 .PHONY: generate
-generate: generate-clean generate-crds generate-client generate-templates generate-manifests bazel-generate
+generate: generate-clean generate-crds generate-client generate-templates generate-csv generate-manifests bazel-generate
 
 .PHONY: generate-clean
 generate-clean:
@@ -46,9 +46,18 @@ generate-crds:
 generate-client:
 	./hack/dockerized "./hack/generate/client.sh"
 
+.PHONY: generate-csv
+generate-csv:
+	./hack/dockerized "./hack/generate/csv.sh"
+
 .PHONY: generate-manifests
 generate-manifests: generate-templates
-	./hack/dockerized "CONTAINER_PREFIX=${CONTAINER_PREFIX} CONTAINER_TAG=${CONTAINER_TAG} ./hack/generate/manifests.sh"
+	./hack/dockerized "CONTAINER_PREFIX=${CONTAINER_PREFIX} \
+		CONTAINER_TAG=${CONTAINER_TAG} \
+		CSV_VERSION=${CSV_VERSION} \
+		CSV_PREVIOUS_VERSION=${CSV_PREVIOUS_VERSION} \
+		IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} \
+		./hack/generate/manifests.sh"
 
 .PHONY: generate-templates
 generate-templates:

--- a/cmd/machine-remediation-operator/BUILD.bazel
+++ b/cmd/machine-remediation-operator/BUILD.bazel
@@ -56,7 +56,10 @@ container_image(
     base = ":crds-image",
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/machine-remediation-operator"],
-    files = [":machine-remediation-operator"],
+    files = [
+        ":machine-remediation-operator",
+        "//tools/csv-generator",
+    ],
     user = "65534",
     visibility = ["//visibility:public"],
 )

--- a/hack/generate/csv.sh
+++ b/hack/generate/csv.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $(dirname "$0")/../common.sh
+
+(cd ${REPO_DIR}/tools/csv-generator/ && go install)
+
+mkdir -p ${GENERATED_MANIFESTS_DIR}
+
+fake_csv_previous_version="1111.1111.1111"
+fake_csv_version="2222.2222.2222"
+csv-generator \
+    --namespace={{.Namespace}} \
+    --repository={{.ContainerPrefix}} \
+    --version={{.ContainerTag}} \
+    --pullPolicy={{.ImagePullPolicy}} \
+    --verbosity={{.Verbosity}} \
+    --csv-version=${fake_csv_version} \
+    --csv-previous-version=${fake_csv_previous_version} \
+    >${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in
+sed -i "s/$fake_csv_version/{{.CSVVersion}}/g" ${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in
+sed -i "s/$fake_csv_previous_version/{{.CSVPreviousVersion}}/g" ${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in

--- a/hack/generate/templates.sh
+++ b/hack/generate/templates.sh
@@ -24,22 +24,5 @@ resource-generator \
     --verbosity={{.Verbosity}} \
     >${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-cr.yaml.in
 
-# Generate CSV
-fake_csv_previous_version="1111.1111.1111"
-fake_csv_version="2222.2222.2222"
-
-resource-generator \
-    --type=csv \
-    --namespace={{.Namespace}} \
-    --repository={{.ContainerPrefix}} \
-    --version={{.ContainerTag}} \
-    --pullPolicy={{.ImagePullPolicy}} \
-    --verbosity={{.Verbosity}} \
-    --csv-version=${fake_csv_version} \
-    --csv-previous-version=${fake_csv_previous_version} \
-    >${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in
-sed -i "s/$fake_csv_version/{{.CSVVersion}}/g" ${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in
-sed -i "s/$fake_csv_previous_version/{{.CSVPreviousVersion}}/g" ${GENERATED_MANIFESTS_DIR}/machine-remediation-operator-csv.yaml.in
-
 #rm -rf cluster-up
 #curl -L https://github.com/kubevirt/kubevirtci/archive/${kubevirtci_git_hash}/kubevirtci.tar.gz | tar xz kubevirtci-${kubevirtci_git_hash}/cluster-up --strip-component 1

--- a/manifests/generated/machine-remediation-operator-csv.yaml.in
+++ b/manifests/generated/machine-remediation-operator-csv.yaml.in
@@ -26,7 +26,7 @@ metadata:
     repository: https://github.com/kubevirt/machine-remediation-operator
     support: KubeVirt
   name: machine-remediation-operator.{{.CSVVersion}}
-  namespace: {{.Namespace}}
+  namespace: placeholder
 spec:
   customresourcedefinitions:
     owned:

--- a/pkg/operator/components/csv.go
+++ b/pkg/operator/components/csv.go
@@ -106,7 +106,7 @@ func NewClusterServiceVersion(data *ClusterServiceVersionData) (*csvv1.ClusterSe
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%s", ComponentMachineRemediationOperator, data.CSVVersion),
-			Namespace: data.Namespace,
+			Namespace: "placeholder",
 			Annotations: map[string]string{
 				"capabilities":   "Full Lifecycle",
 				"categories":     "OpenShift Optional",

--- a/tools/csv-generator/BUILD.bazel
+++ b/tools/csv-generator/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["csv-generator.go"],
+    importpath = "kubevirt.io/machine-remediation-operator/tools/csv-generator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/operator/components:go_default_library",
+        "//tools/utils:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "csv-generator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"kubevirt.io/machine-remediation-operator/pkg/operator/components"
+	"kubevirt.io/machine-remediation-operator/tools/utils"
+)
+
+func main() {
+	namespace := flag.String("namespace", "opensgift-machine-api", "Namespace to use.")
+	repository := flag.String("repository", "index.docker.io/kubevirt", "Image Repository to use.")
+	version := flag.String("version", "latest", "version to use.")
+	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
+	verbosity := flag.String("verbosity", "2", "Verbosity level to use.")
+	csvVersion := flag.String("csv-version", "0.0.0", "ClusterServiceVersion version.")
+	csvPreviousVersion := flag.String("csv-previous-version", "", "ClusterServiceVersion version to replace.")
+
+	flag.Parse()
+
+	imagePullPolicy := corev1.PullPolicy(*pullPolicy)
+	data := &components.ClusterServiceVersionData{
+		CSVVersion:         *csvVersion,
+		ContainerPrefix:    *repository,
+		ContainerTag:       *version,
+		ImagePullPolicy:    imagePullPolicy,
+		Namespace:          *namespace,
+		ReplacesCSVVersion: *csvPreviousVersion,
+		Verbosity:          *verbosity,
+	}
+	csv, err := components.NewClusterServiceVersion(data)
+	if err != nil {
+		panic(fmt.Errorf("failed to get CSV component: %v", err))
+	}
+	utils.MarshallObject(csv, os.Stdout)
+}

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -39,10 +39,6 @@ func main() {
 	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
 	verbosity := flag.String("verbosity", "2", "Verbosity level to use.")
 
-	// CSV specific arguments
-	csvVersion := flag.String("csv-version", "0.0.0", "ClusterServiceVersion version.")
-	csvPreviousVersion := flag.String("csv-previous-version", "", "ClusterServiceVersion version to replace.")
-
 	flag.Parse()
 
 	imagePullPolicy := corev1.PullPolicy(*pullPolicy)
@@ -77,21 +73,6 @@ func main() {
 		mro := components.NewMachineRemediationOperator(*resourceType, *namespace, *repository, imagePullPolicy, *version)
 		mro.Name = "mro"
 		utils.MarshallObject(mro, os.Stdout)
-	case "csv":
-		data := &components.ClusterServiceVersionData{
-			CSVVersion:         *csvVersion,
-			ContainerPrefix:    *repository,
-			ContainerTag:       *version,
-			ImagePullPolicy:    imagePullPolicy,
-			Namespace:          *namespace,
-			ReplacesCSVVersion: *csvPreviousVersion,
-			Verbosity:          *verbosity,
-		}
-		csv, err := components.NewClusterServiceVersion(data)
-		if err != nil {
-			panic(fmt.Errorf("failed to get CSV component: %v", err))
-		}
-		utils.MarshallObject(csv, os.Stdout)
 	default:
 		panic(fmt.Errorf("unknown resource type %s", *resourceType))
 	}


### PR DESCRIPTION
For example this command
`docker run -it --rm --entrypoint /usr/bin/csv-generator $CSV_GENERATOR_IMAGE --namespace=openshift-machine-api --repository=docker.io/alukiano --version=v0.3.4 --pullPolicy=Always --verbosity=2 -csv-version=0.3.4 --csv-previous-version=0.3.3`

will generate

```yaml
---
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  annotations:
    alm-examples: |-
      [
        {
          "apiVersion":"machineremediation.kubevirt.io/v1alpha1",
          "kind":"MachineRemediationOperator",
          "metadata": {
            "name":"mro",
            "namespace":"openshift-machine-api"
          },
          "spec": {
            "imagePullPolicy":"IfNotPresent",
          }
        }
      ]
    capabilities: Full Lifecycle
    categories: OpenShift Optional
    certified: "false"
    containerImage: docker.io/alukiano/machine-remediation-operator:v0.3.4
    createdAt: ""
    description: Deploys components to monitor and remediate unhealthy machines
    repository: https://github.com/kubevirt/machine-remediation-operator
    support: KubeVirt
  name: machine-remediation-operator.0.3.4
  namespace: placeholder
spec:
  customresourcedefinitions:
    owned:
    - description: Represents a Machine Remediation Operator deployment
      displayName: Machine Remediation Operator deployment
      kind: MachineRemediationOperator
      name: machineremediationoperators.machineremediation.kubevirt.io
      specDescriptors:
      - description: The ImagePullPolicy to use for the Machine Remediation components.
        displayName: ImagePullPolicy
        path: imagePullPolicy
        x-descriptors:
        - urn:alm:descriptor:io.kubernetes:imagePullPolicy
      - description: The ImageRegistry to use for the Machine Remediation components.
        displayName: ImageRegistry
        path: imageRegistry
        x-descriptors:
        - urn:alm:descriptor:text
      - description: The ImageTag to use for the Machine Remediation components.
        displayName: ImageTag
        path: imageTag
        x-descriptors:
        - urn:alm:descriptor:text
      statusDescriptors:
      - description: Explanation for the current status of the cluster.
        displayName: Conditions
        path: conditions
        x-descriptors:
        - urn:alm:descriptor:io.kubernetes.conditions
      version: v1alpha1
  description: |-
    The **machine remediation operator** deploys components to monitor and remediate unhealthy machines for different platforms, it works on top of cluster-api controllers.

    It should deploy three controllers:

    * [machine-health-check](https://github.com/kubevirt/machine-remediation-operator/blob/master/docs/machine-health-check.md) controller
    * [machine-disruption-budget](https://github.com/kubevirt/machine-remediation-operator/blob/master/docs/machine-disruption-budget.md) controller
    * [machine-remediation](https://github.com/kubevirt/machine-remediation-operator/blob/master/docs/machine-remediation.md) controller
  displayName: Machine Remediation Operator
  install:
    spec:
      clusterPermissions:
      - rules:
        - apiGroups:
          - machineremediation.kubevirt.io
          resources:
          - machineremediationoperators
          - machineremediationoperators/status
          verbs:
          - get
          - list
          - update
          - watch
        - apiGroups:
          - ""
          resources:
          - serviceaccounts
          verbs:
          - '*'
        - apiGroups:
          - apps
          resources:
          - deployments
          verbs:
          - '*'
        - apiGroups:
          - apiextensions.k8s.io
          resources:
          - customresourcedefinitions
          verbs:
          - '*'
        - apiGroups:
          - rbac.authorization.k8s.io
          resources:
          - clusterroles
          - clusterrolebindings
          verbs:
          - '*'
        serviceAccountName: machine-remediation-operator
      deployments:
      - name: machine-remediation-operator
        spec:
          replicas: 1
          selector:
            matchLabels:
              machineremediation.kubevirt.io: machine-remediation-operator
              machineremediation.kubevirt.io/version: v0.3.4
          strategy:
            type: RollingUpdate
          template:
            metadata:
              creationTimestamp: null
              labels:
                machineremediation.kubevirt.io: machine-remediation-operator
                machineremediation.kubevirt.io/version: v0.3.4
            spec:
              containers:
              - args:
                - --logtostderr=true
                - --v=2
                - --namespace=openshift-machine-api
                command:
                - /usr/bin/machine-remediation-operator
                env:
                - name: OPERATOR_VERSION
                  value: v0.3.4
                image: docker.io/alukiano/machine-remediation-operator:v0.3.4
                imagePullPolicy: Always
                name: machine-remediation-operator
                resources:
                  requests:
                    cpu: 10m
                    memory: 20Mi
              nodeSelector:
                node-role.kubernetes.io/master: ""
              securityContext:
                runAsNonRoot: true
              serviceAccountName: machine-remediation-operator
              tolerations:
              - effect: NoSchedule
                key: node-role.kubernetes.io/master
              - key: CriticalAddonsOnly
                operator: Exists
              - effect: NoExecute
                key: node.kubernetes.io/not-ready
                operator: Exists
                tolerationSeconds: 120
              - effect: NoExecute
                key: node.kubernetes.io/unreachable
                operator: Exists
                tolerationSeconds: 120
    strategy: deployment
  installModes:
  - supported: true
    type: OwnNamespace
  - supported: true
    type: SingleNamespace
  - supported: false
    type: MultiNamespace
  - supported: false
    type: AllNamespaces
  keywords:
  - remediation
  - fencing
  - HA
  - health
  - cluster-api
  labels:
    alm-owner-kubevirt: machineremediationoperator
    operated-by: machineremediationoperator
  links:
  - name: KubeVirt
    url: https://kubevirt.io
  - name: Source Code
    url: https://github.com/kubevirt/machine-remediation-operator
  maintainers:
  - email: kubevirt-dev@googlegroups.com
    name: KubeVirt project
  maturity: alpha
  provider:
    name: Machine Remediation Operator project
  replaces: machine-remediation-operator.0.3.3
  selector:
    matchLabels:
      alm-owner-kubevirt: machineremediationoperator
      operated-by: machineremediationoperator
  version: 0.3.4
```