### PR TITLE
Add support for node annotation to disable node fencing

### DIFF
--- a/pkg/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -30,6 +30,7 @@ import (
 const (
 	machineAnnotationKey = "machine.openshift.io/machine"
 	ownerControllerKind  = "MachineSet"
+	disableRemediationAnotationKey = "healthchecking.openshift.io/disabled"
 )
 
 // Add creates a new MachineHealthCheck Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -128,7 +129,13 @@ func (r *ReconcileMachineHealthCheck) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	if hasRemediationDisabledAnnotation(*machine) {
+		glog.Infof("Machine %s has a matching %s annotation set to <true>, remediation is skipped.",
+			machineKey, disableRemediationAnotationKey)
+		return reconcile.Result{}, nil
+	}	
 	for _, hc := range allMachineHealthChecks.Items {
+
 		if hasMatchingLabels(&hc, machine) {
 			glog.V(4).Infof("Machine %s has a matching machineHealthCheck: %s", machineKey, hc.Name)
 			return remediate(r, hc.Spec.RemediationStrategy, machine)
@@ -321,6 +328,15 @@ func hasMachineSetOwner(machine mapiv1.Machine) bool {
 	}
 	return false
 }
+
+func hasRemediationDisabledAnnotation(machine mapiv1.Machine) bool {
+	skipRemediation, ok := machine.Annotations[disableRemediationAnotationKey]
+	if !ok {
+		return false
+	}
+	return skipRemediation == "true"
+}
+
 
 func hasMatchingLabels(machineHealthCheck *mrv1.MachineHealthCheck, machine *mapiv1.Machine) bool {
 	selector, err := metav1.LabelSelectorAsSelector(&machineHealthCheck.Spec.Selector)

--- a/pkg/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -162,6 +162,12 @@ func testReconcile(t *testing.T, remediationWaitTime time.Duration, initObjects 
 	nodeUnhealthyForTooLong := mrotesting.NewNode("nodeUnhealthyForTooLong", false, "machineUnhealthyForTooLong")
 	machineUnhealthyForTooLong := mrotesting.NewMachine("machineUnhealthyForTooLong", nodeUnhealthyForTooLong.Name, "")
 
+	// remediation disabled annotation 
+
+	nodeWithRemediationDisabled := mrotesting.NewNode("nodeWithRemediationDisabled", true, "machineWithRemediationDisabled")
+	machineWithRemediationDisabled := mrotesting.NewMachine("machineWithRemediationDisabled", "node", "")
+	machineWithRemediationDisabled.Annotations[disableRemediationAnotationKey] = "true"
+
 	testsCases := []struct {
 		machine             *mapiv1.Machine
 		node                *corev1.Node
@@ -226,6 +232,14 @@ func testReconcile(t *testing.T, remediationWaitTime time.Duration, initObjects 
 			expected: expectedReconcile{
 				result: reconcile.Result{},
 				error:  true,
+			},
+		},
+		{
+			machine: machineWithRemediationDisabled,
+			node:    nodeWithRemediationDisabled,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
 			},
 		},
 	}


### PR DESCRIPTION
Adding "healthchecking.openshift.io/disabled=true" annotation to the machine object will
disable fencing on that machine until annotation is set again to false.