### PR TITLE
Do not skip remediation when the machine does not have machineset

### DIFF
--- a/pkg/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -316,7 +316,7 @@ func TestHasMachineSetOwner(t *testing.T) {
 	}
 
 	for _, tc := range testsCases {
-		if got := hasMachineSetOwner(*tc.machine); got != tc.expected {
+		if got := hasMachineSetOwner(tc.machine); got != tc.expected {
 			t.Errorf("Test case: Machine %s. Expected: %t, got: %t", tc.machine.Name, tc.expected, got)
 		}
 	}

--- a/pkg/controllers/machineremediation/BUILD.bazel
+++ b/pkg/controllers/machineremediation/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/apis/machineremediation/v1alpha1:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/controller:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/handler:go_default_library",

--- a/pkg/controllers/machineremediation/machineremediation_controller.go
+++ b/pkg/controllers/machineremediation/machineremediation_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	mrv1 "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1"
 
@@ -26,6 +27,7 @@ type ReconcileMachineRemediation struct {
 	// that reads objects from the cache and writes to the apiserver
 	client     client.Client
 	remediator Remediator
+	scheme     *runtime.Scheme
 	namespace  string
 }
 
@@ -42,6 +44,7 @@ func AddWithRemediator(mgr manager.Manager, remediator Remediator, opts manager.
 func newReconciler(mgr manager.Manager, remediator Remediator, opts manager.Options) (reconcile.Reconciler, error) {
 	return &ReconcileMachineRemediation{
 		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
 		remediator: remediator,
 		namespace:  opts.Namespace,
 	}, nil


### PR DESCRIPTION
On the bare metal environment, we have dummy machines without machine set
owner reference, but we do not want to skip remediation in this case.