### PR TITLE
Use machine master role label on masters MHC and MDB resources

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -11,12 +11,14 @@ const (
 	ControllerMachineHealthCheck = "machine-health-check"
 	// ControllerMachineRemediation contains the name of achineRemediation controller
 	ControllerMachineRemediation = "machine-remediation"
-	//MasterRoleLabel contains master role label
-	MasterRoleLabel = "node-role.kubernetes.io/master"
+	//MachineRoleLabel contains machine role label
+	MachineRoleLabel = "machine.openshift.io/cluster-api-machine-role"
 	// MasterMachineHealthCheck contains the MachineHealthCheck name for master nodes
 	MasterMachineHealthCheck = "masters"
 	// MasterMachineDisruptionBudget contains the MachineDisruptionBudget name for master nodes
 	MasterMachineDisruptionBudget = "masters"
 	// NamespaceOpenshiftMachineAPI contains namespace name for the machine-api componenets under the OpenShift cluster
 	NamespaceOpenshiftMachineAPI = "openshift-machine-api"
+	//NodeMasterRoleLabel contains node master role label
+	NodeMasterRoleLabel = "node-role.kubernetes.io/master"
 )

--- a/pkg/operator/components/mdb.go
+++ b/pkg/operator/components/mdb.go
@@ -26,7 +26,7 @@ func NewMastersMachineDisruptionBudget(name string, namespace string, operatorVe
 		Spec: mrv1.MachineDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					consts.MasterRoleLabel: "",
+					consts.MachineRoleLabel: "master",
 				},
 			},
 			MinAvailable: pointer.Int32Ptr(1),

--- a/pkg/operator/components/mhc.go
+++ b/pkg/operator/components/mhc.go
@@ -26,7 +26,7 @@ func NewMastersMachineHealthCheck(name string, namespace string, operatorVersion
 		Spec: mrv1.MachineHealthCheckSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					consts.MasterRoleLabel: "",
+					consts.MachineRoleLabel: "master",
 				},
 			},
 			RemediationStrategy: &rebootStrategy,

--- a/pkg/operator/resources.go
+++ b/pkg/operator/resources.go
@@ -87,7 +87,7 @@ func (r *ReconcileMachineRemediationOperator) getReplicasCount() (int32, error) 
 		context.TODO(),
 		masterNodes,
 		client.InNamespace(consts.NamespaceOpenshiftMachineAPI),
-		client.MatchingLabels(map[string]string{consts.MasterRoleLabel: ""}),
+		client.MatchingLabels(map[string]string{consts.NodeMasterRoleLabel: ""}),
 	); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
MHC and MDB controllers looks for the relevant resources by machine and not by node label.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>