### PR TITLE
chore(dep): remove version from deploy immutables

### DIFF
--- a/manifests/generated/machine-remediation-operator-csv.yaml.in
+++ b/manifests/generated/machine-remediation-operator-csv.yaml.in
@@ -132,7 +132,6 @@ spec:
           selector:
             matchLabels:
               machineremediation.kubevirt.io: machine-remediation-operator
-              machineremediation.kubevirt.io/version: {{.ContainerTag}}
           strategy:
             type: RollingUpdate
           template:
@@ -140,7 +139,6 @@ spec:
               creationTimestamp: null
               labels:
                 machineremediation.kubevirt.io: machine-remediation-operator
-                machineremediation.kubevirt.io/version: {{.ContainerTag}}
             spec:
               affinity:
                 podAntiAffinity:

--- a/manifests/generated/machine-remediation-operator.yaml.in
+++ b/manifests/generated/machine-remediation-operator.yaml.in
@@ -104,14 +104,12 @@ spec:
   selector:
     matchLabels:
       machineremediation.kubevirt.io: machine-remediation-operator
-      machineremediation.kubevirt.io/version: {{.ContainerTag}}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
         machineremediation.kubevirt.io: machine-remediation-operator
-        machineremediation.kubevirt.io/version: {{.ContainerTag}}
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/operator/components/deployments.go
+++ b/pkg/operator/components/deployments.go
@@ -49,8 +49,7 @@ func NewDeployment(data *DeploymentData) *appsv1.Deployment {
 			Replicas: pointer.Int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					mrv1.SchemeGroupVersion.Group:              data.Name,
-					mrv1.SchemeGroupVersion.Group + "/version": data.OperatorVersion,
+					mrv1.SchemeGroupVersion.Group: data.Name,
 				},
 			},
 			Template: *template,
@@ -86,8 +85,7 @@ func newPodTemplateSpec(data *DeploymentData) *corev1.PodTemplateSpec {
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				mrv1.SchemeGroupVersion.Group:              data.Name,
-				mrv1.SchemeGroupVersion.Group + "/version": data.OperatorVersion,
+				mrv1.SchemeGroupVersion.Group: data.Name,
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
When the MRO is updated via OLM, OLM will attempt to patch the
deployment spec. Unfortunately, some of these fields are immutable. This
PR removes immutable fields that would change across
ClusterServiceVersions.

Ref: https://github.com/operator-framework/operator-lifecycle-manager/issues/952
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1753797