### PR TITLE
Set reboot annotation on the bare metal host

### DIFF
--- a/pkg/baremetal/remediator/BUILD.bazel
+++ b/pkg/baremetal/remediator/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/machineremediation/v1alpha1:go_default_library",
+        "//pkg/consts:go_default_library",
         "//pkg/utils/testing:go_default_library",
         "//vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -5,6 +5,8 @@ const (
 	AnnotationBareMetalHost = "metal3.io/BareMetalHost"
 	// AnnotationMachine contains the annotation key for machine
 	AnnotationMachine = "machine.openshift.io/machine"
+	// AnnotationRebootInProgress contains the annotation key, that indicates that reboot in the progress
+	AnnotationRebootInProgress = "machineremediation.kubevirt.io/rebootInProgress"
 	// ControllerMachineDisruptionBudget contains the name of MachineDisruptionBudget controller
 	ControllerMachineDisruptionBudget = "machine-disruption-budget"
 	// ControllerMachineHealthCheck contains the name of MachineHealthCheck controller


### PR DESCRIPTION
When we need to remediate the node that currently runs the remediation controller, possible situation when we will poweroff the host, and until all controller will restart on other node, the reboot will failed on the timeout and the node will stay in poweroff state forever, because first reboot failed and the others will succeed because host already has `spec.Online` parameter equals to `false`, so the controller will think that an user power offed it by purpose.

To prevent it we will set annotation on the `BareMetalHost` resource, before
poweroff operation and remove it after poweron, in this case, if the first
reboot will fail, the one that will follow it, will recognize annotation and will know
the reboot process initiated by the system and not by the user.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>