### PR TITLE
Introduce the node reboot controller

### DIFF
--- a/cmd/machine-remediation/BUILD.bazel
+++ b/cmd/machine-remediation/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/baremetal/remediator:go_default_library",
         "//pkg/controllers:go_default_library",
         "//pkg/controllers/machineremediation:go_default_library",
+        "//pkg/controllers/nodereboot:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1:go_default_library",

--- a/cmd/machine-remediation/main.go
+++ b/cmd/machine-remediation/main.go
@@ -11,6 +11,7 @@ import (
 	"kubevirt.io/machine-remediation-operator/pkg/baremetal/remediator"
 	"kubevirt.io/machine-remediation-operator/pkg/controllers"
 	"kubevirt.io/machine-remediation-operator/pkg/controllers/machineremediation"
+	"kubevirt.io/machine-remediation-operator/pkg/controllers/nodereboot"
 	"kubevirt.io/machine-remediation-operator/pkg/version"
 
 	mapiv1 "sigs.k8s.io/cluster-api/pkg/apis/machine/v1beta1"
@@ -72,7 +73,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err := controllers.AddToManager(mgr, opts, addController); err != nil {
+	if err := controllers.AddToManager(mgr, opts, addController, nodereboot.Add); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/pkg/baremetal/remediator/remediator.go
+++ b/pkg/baremetal/remediator/remediator.go
@@ -175,6 +175,7 @@ func (bmr *BareMetalRemediator) Reboot(ctx context.Context, machineRemediation *
 		}
 		return nil
 
+	// assumption that the reboot annotation removed because of node removal
 	case mrv1.RemediationStateSucceeded:
 		// remove machine remediation object
 		return bmr.client.Delete(context.TODO(), machineRemediation)
@@ -260,9 +261,15 @@ func isRebootInProgress(bmh *bmov1.BareMetalHost) bool {
 // removeNodeRebootAnnotation removes the reboot annotation from the node
 func removeNodeRebootAnnotation(c client.Client, node *corev1.Node) error {
 	nodeCopy := node.DeepCopy()
+
+	if nodeCopy.Annotations == nil {
+		return nil
+	}
+
 	if _, ok := nodeCopy.Annotations[consts.AnnotationNodeMachineReboot]; !ok {
 		return nil
 	}
+
 	delete(nodeCopy.Annotations, consts.AnnotationNodeMachineReboot)
-	return c.Update(context.TODO(), node)
+	return c.Update(context.TODO(), nodeCopy)
 }

--- a/pkg/baremetal/remediator/remediator_test.go
+++ b/pkg/baremetal/remediator/remediator_test.go
@@ -43,10 +43,15 @@ type expectedRemediationResult struct {
 	nodeDeleted                     bool
 	machineRemediationDeleted       bool
 	rebootInProgressAnnotationExist bool
+	nodeRebootAnnotationExist       bool
 }
 
 func TestRemediationReboot(t *testing.T) {
 	nodeOnline := mrotesting.NewNode("nodeOnline", true, "machineOnline")
+	nodeOnline.Annotations = map[string]string{
+		consts.AnnotationNodeMachineReboot: "",
+	}
+
 	bareMetalHostOnline := mrotesting.NewBareMetalHost("bareMetalHostOnline", true, true)
 	bareMetalHostOnline.Annotations[consts.AnnotationRebootInProgress] = "true"
 	machineOnline := mrotesting.NewMachine("machineOnline", nodeOnline.Name, bareMetalHostOnline.Name)
@@ -55,6 +60,9 @@ func TestRemediationReboot(t *testing.T) {
 	machineOnlineWithoutRebootAnnotation := mrotesting.NewMachine("machineOnlineWithoutRebootAnnotation", nodeOnline.Name, bareMetalHostOnlineWithoutRebootAnnotation.Name)
 
 	nodeOffline := mrotesting.NewNode("nodeOffline", false, "machineOffline")
+	nodeOffline.Annotations = map[string]string{
+		consts.AnnotationNodeMachineReboot: "",
+	}
 
 	bareMetalHostOffline := mrotesting.NewBareMetalHost("bareMetalHostOffline", false, false)
 	machineOffline := mrotesting.NewMachine("machineOffline", nodeOffline.Name, bareMetalHostOffline.Name)
@@ -64,6 +72,10 @@ func TestRemediationReboot(t *testing.T) {
 	machineOfflineWithRebootAnnotation := mrotesting.NewMachine("machineOfflineWithRebootAnnotation", nodeOffline.Name, bareMetalHostOfflineWithRebootAnnotation.Name)
 
 	nodeNotReady := mrotesting.NewNode("nodeNotReady", false, "machineNotReady")
+	nodeNotReady.Annotations = map[string]string{
+		consts.AnnotationNodeMachineReboot: "",
+	}
+
 	bareMetalHostNotReady := mrotesting.NewBareMetalHost("bareMetalHostNotReady", true, true)
 	machineNotReady := mrotesting.NewMachine("machineNotReady", nodeNotReady.Name, bareMetalHostNotReady.Name)
 
@@ -82,6 +94,7 @@ func TestRemediationReboot(t *testing.T) {
 	}
 	machineRemediationPoweronNotReady := mrotesting.NewMachineRemediation("machineRemediationPoweronNotReady", machineNotReady.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStatePowerOn)
 	machineRemediationSucceeded := mrotesting.NewMachineRemediation("machineRemediationSucceeded", machineOnline.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateSucceeded)
+	machineRemediationFailed := mrotesting.NewMachineRemediation("machineRemediationFailed", machineOnline.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateFailed)
 	machineRemediationStartedOfflineWithRebootInProgressAnnotation := mrotesting.NewMachineRemediation("machineRemediationStartedOfflineWithRebootInProgressAnnotation", machineOfflineWithRebootAnnotation.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateStarted)
 	machineRemediationStartedOnlineWithoutRebootInProgressAnnotation := mrotesting.NewMachineRemediation("machineRemediationStartedOnlineWithoutRebootInProgressAnnotation", machineOnlineWithoutRebootAnnotation.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateStarted)
 	machineRemediationPoweroffOnlineWithRebootInProgressAnnotation := mrotesting.NewMachineRemediation("machineRemediationPoweroffOnlineWithRebootInProgressAnnotation", machineOfflineWithRebootAnnotation.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStatePowerOff)
@@ -105,6 +118,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: false,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -119,6 +133,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -133,6 +148,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -147,6 +163,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     true,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: false,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -161,6 +178,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -175,6 +193,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: false,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -189,6 +208,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -203,6 +223,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -217,6 +238,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: false,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -231,6 +253,22 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       true,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
+			},
+		},
+		{
+			name:               "with machine remediation in failed state",
+			machineRemediation: machineRemediationFailed,
+			bareMetalHost:      bareMetalHostOnline,
+			node:               nodeOnline,
+			expected: expectedRemediationResult{
+				state:                           mrv1.RemediationStateFailed,
+				hasEndTime:                      false,
+				bareMetalHostOnline:             true,
+				nodeDeleted:                     false,
+				machineRemediationDeleted:       false,
+				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       false,
 			},
 		},
 		{
@@ -245,6 +283,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     false,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: true,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 		{
@@ -259,6 +298,7 @@ func TestRemediationReboot(t *testing.T) {
 				nodeDeleted:                     true,
 				machineRemediationDeleted:       false,
 				rebootInProgressAnnotationExist: false,
+				nodeRebootAnnotationExist:       true,
 			},
 		},
 	}
@@ -357,6 +397,13 @@ func TestRemediationReboot(t *testing.T) {
 
 		if err == nil && tc.expected.nodeDeleted {
 			t.Errorf("%s failed, expected node %s to be not deleted", tc.name, node.Name)
+		}
+
+		if node != nil && node.Annotations != nil {
+			_, ok := node.Annotations[consts.AnnotationNodeMachineReboot]
+			if tc.expected.nodeRebootAnnotationExist != ok {
+				t.Errorf("%s failed, expected node reboot annotation %t, got %t", tc.name, tc.expected.nodeRebootAnnotationExist, ok)
+			}
 		}
 	}
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -5,6 +5,9 @@ const (
 	AnnotationBareMetalHost = "metal3.io/BareMetalHost"
 	// AnnotationMachine contains the annotation key for machine
 	AnnotationMachine = "machine.openshift.io/machine"
+	// AnnotationNodeMachineReboot contains machine reboot annotation key, once nodereboot controller will detect it,
+	// it will create the MachineRemediation object
+	AnnotationNodeMachineReboot = "healthchecking.openshift.io/machine-remediation-reboot"
 	// AnnotationRebootInProgress contains the annotation key, that indicates that reboot in the progress
 	AnnotationRebootInProgress = "machineremediation.kubevirt.io/rebootInProgress"
 	//MachineRoleLabel contains machine role label

--- a/pkg/controllers/nodereboot/BUILD.bazel
+++ b/pkg/controllers/nodereboot/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["nodereboot.go"],
+    importpath = "kubevirt.io/machine-remediation-operator/pkg/controllers/nodereboot",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/machineremediation/v1alpha1:go_default_library",
+        "//pkg/consts:go_default_library",
+        "//pkg/utils/machines:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/controller:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/handler:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/reconcile:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/source:go_default_library",
+    ],
+)

--- a/pkg/controllers/nodereboot/BUILD.bazel
+++ b/pkg/controllers/nodereboot/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["nodereboot.go"],
+    srcs = ["nodereboot_controller.go"],
     importpath = "kubevirt.io/machine-remediation-operator/pkg/controllers/nodereboot",
     visibility = ["//visibility:public"],
     deps = [
@@ -19,5 +19,25 @@ go_library(
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/reconcile:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/source:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["nodereboot_controller_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/machineremediation/v1alpha1:go_default_library",
+        "//pkg/consts:go_default_library",
+        "//pkg/utils/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/sigs.k8s.io/cluster-api/pkg/apis/machine/v1beta1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/reconcile:go_default_library",
     ],
 )

--- a/pkg/controllers/nodereboot/nodereboot.go
+++ b/pkg/controllers/nodereboot/nodereboot.go
@@ -1,0 +1,137 @@
+package nodereboot
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+
+	mrv1 "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1"
+	"kubevirt.io/machine-remediation-operator/pkg/consts"
+	machineutils "kubevirt.io/machine-remediation-operator/pkg/utils/machines"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var _ reconcile.Reconciler = &ReconcileNodeReboot{}
+
+// ReconcileNodeReboot reconciles a node object
+type ReconcileNodeReboot struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client    client.Client
+	namespace string
+}
+
+// Add creates a new NodeReboot Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and start it when the Manager is started.
+func Add(mgr manager.Manager, opts manager.Options) error {
+	r, err := newReconciler(mgr, opts)
+	if err != nil {
+		return err
+	}
+	return add(mgr, r)
+}
+
+func newReconciler(mgr manager.Manager, opts manager.Options) (reconcile.Reconciler, error) {
+	return &ReconcileNodeReboot{
+		client:    mgr.GetClient(),
+		namespace: opts.Namespace,
+	}, nil
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("nodereboot-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{})
+}
+
+// Reconcile monitors Nodes and creates the MachineRemediation object when the node has reboot annotation.
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileNodeReboot) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	glog.Infof("Reconciling node %s/%s\n", request.Namespace, request.Name)
+
+	// Get node from request
+	node := &corev1.Node{}
+	if err := r.client.Get(context.TODO(), request.NamespacedName, node); err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	if node.Annotations == nil {
+		return reconcile.Result{}, nil
+	}
+
+	if _, ok := node.Annotations[consts.AnnotationNodeMachineReboot]; !ok {
+		return reconcile.Result{}, nil
+	}
+
+	// Verify that we do not have machine remediation in progress
+	machine, err := machineutils.GetMachineByNode(r.client, node)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	rebootInProgress, err := isRebootInProgress(r.client, machine.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if rebootInProgress {
+		return reconcile.Result{}, nil
+	}
+
+	// Creates new machine remediation object
+	mr := &mrv1.MachineRemediation{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "remediation-",
+			Namespace:    machine.Namespace,
+		},
+		Spec: mrv1.MachineRemediationSpec{
+			MachineName: machine.Name,
+			Type:        mrv1.RemediationTypeReboot,
+		},
+	}
+
+	if err = r.client.Create(context.TODO(), mr); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func isRebootInProgress(c client.Client, machineName string) (bool, error) {
+	machineRemediations := &mrv1.MachineRemediationList{}
+	if err := c.List(context.TODO(), machineRemediations); err != nil {
+		return false, err
+	}
+
+	for _, mr := range machineRemediations.Items {
+		if mr.Spec.MachineName == machineName {
+			if mr.Status.EndTime != nil {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/controllers/nodereboot/nodereboot_controller.go
+++ b/pkg/controllers/nodereboot/nodereboot_controller.go
@@ -126,12 +126,15 @@ func isRebootInProgress(c client.Client, machineName string) (bool, error) {
 		return false, err
 	}
 
+	rebootInProgress := false
+
 	for _, mr := range machineRemediations.Items {
 		if mr.Spec.MachineName == machineName {
-			if mr.Status.EndTime != nil {
-				return true, nil
+			if mr.Status.EndTime == nil {
+				rebootInProgress = true
+				break
 			}
 		}
 	}
-	return false, nil
+	return rebootInProgress, nil
 }

--- a/pkg/controllers/nodereboot/nodereboot_controller_test.go
+++ b/pkg/controllers/nodereboot/nodereboot_controller_test.go
@@ -1,0 +1,104 @@
+package nodereboot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	mrv1 "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1"
+	"kubevirt.io/machine-remediation-operator/pkg/consts"
+	mrotesting "kubevirt.io/machine-remediation-operator/pkg/utils/testing"
+
+	mapiv1 "sigs.k8s.io/cluster-api/pkg/apis/machine/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	// Add types to scheme
+	mrv1.AddToScheme(scheme.Scheme)
+	mapiv1.AddToScheme(scheme.Scheme)
+}
+
+// newFakeReconciler returns a new reconcile.Reconciler with a fake client
+func newFakeReconciler(initObjects ...runtime.Object) *ReconcileNodeReboot {
+	fakeClient := fake.NewFakeClient(initObjects...)
+	return &ReconcileNodeReboot{
+		client:    fakeClient,
+		namespace: consts.NamespaceOpenshiftMachineAPI,
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	nodeWithRebootAnnotation := mrotesting.NewNode("nodeWithRebootAnnotation", true, "machineWithRebootAnnotation")
+	nodeWithRebootAnnotation.Annotations[consts.AnnotationNodeMachineReboot] = ""
+	machineWithRebootAnnotation := mrotesting.NewMachine("machineWithRebootAnnotation", nodeWithRebootAnnotation.Name, "")
+
+	nodeWithoutRebootAnnotation := mrotesting.NewNode("nodeWithoutRebootAnnotation", true, "machineWithoutRebootAnnotation")
+	machineWithoutRebootAnnotation := mrotesting.NewMachine("machineWithoutRebootAnnotation", nodeWithoutRebootAnnotation.Name, "")
+
+	machineRemediationEnded := mrotesting.NewMachineRemediation("machineRemediationEnded", machineWithRebootAnnotation.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateFailed)
+	machineRemediationEnded.Status.EndTime = &metav1.Time{Time: time.Now()}
+	machineRemediationNotEnded := mrotesting.NewMachineRemediation("machineRemediationNotEnded", machineWithRebootAnnotation.Name, mrv1.RemediationTypeReboot, mrv1.RemediationStateStarted)
+
+	testsCases := []struct {
+		node                           *corev1.Node
+		machineRemdiation              *mrv1.MachineRemediation
+		expectedNumMachineRemediations int
+	}{
+		{
+			node:                           nodeWithRebootAnnotation,
+			machineRemdiation:              nil,
+			expectedNumMachineRemediations: 1,
+		},
+		{
+			node:                           nodeWithoutRebootAnnotation,
+			machineRemdiation:              nil,
+			expectedNumMachineRemediations: 0,
+		},
+		{
+			node:                           nodeWithRebootAnnotation,
+			machineRemdiation:              machineRemediationEnded,
+			expectedNumMachineRemediations: 2,
+		},
+		{
+			node:                           nodeWithRebootAnnotation,
+			machineRemdiation:              machineRemediationNotEnded,
+			expectedNumMachineRemediations: 1,
+		},
+	}
+
+	for _, tc := range testsCases {
+		objects := []runtime.Object{
+			machineWithRebootAnnotation,
+			machineWithoutRebootAnnotation,
+			tc.node,
+		}
+		if tc.machineRemdiation != nil {
+			objects = append(objects, tc.machineRemdiation)
+		}
+		r := newFakeReconciler(objects...)
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: metav1.NamespaceNone,
+				Name:      tc.node.Name,
+			},
+		}
+		result, err := r.Reconcile(request)
+		assert.NoError(t, err)
+		assert.Equal(t, result, reconcile.Result{})
+
+		mrList := &mrv1.MachineRemediationList{}
+		assert.NoError(t, r.client.List(context.TODO(), mrList))
+
+		assert.Equal(t, len(mrList.Items), tc.expectedNumMachineRemediations)
+	}
+}

--- a/pkg/utils/machines/BUILD.bazel
+++ b/pkg/utils/machines/BUILD.bazel
@@ -7,11 +7,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/machineremediation/v1alpha1:go_default_library",
+        "//pkg/consts:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/machine/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,12 +273,12 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/api/resource
+k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1/validation
 k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/util/validation/field
-k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/fields
@@ -316,6 +316,7 @@ k8s.io/client-go/discovery/fake
 k8s.io/client-go/testing
 k8s.io/client-go/tools/record
 k8s.io/client-go/util/retry
+k8s.io/client-go/restmapper
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/tools/leaderelection
@@ -337,7 +338,6 @@ k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/util/homedir
 k8s.io/client-go/kubernetes/typed/coordination/v1
 k8s.io/client-go/kubernetes/typed/core/v1
-k8s.io/client-go/restmapper
 k8s.io/client-go/kubernetes
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1


### PR DESCRIPTION
This controller should monitor nodes and when it will detect
the reboot annotation, it will create `MachineRemediation` object.

TODO:
- [x] should remove the reboot annotation, once the reboot succeeded or failed
- [x] add unittests


Signed-off-by: Artyom Lukianov <alukiano@redhat.com>